### PR TITLE
feat: allow callable tool functions

### DIFF
--- a/Easy-gpt/__init__.py
+++ b/Easy-gpt/__init__.py
@@ -1,0 +1,10 @@
+"""Public package interface for Easy-GPT.
+
+Exposes the :class:`~easy_gpt.assistant.Assistant` helper along with literal
+type aliases for common models and conversation roles.
+"""
+
+from .assistant import Assistant, Context, ModelName, Role
+
+__all__ = ["Assistant", "ModelName", "Role", "Context"]
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# Easy GPT
+
+Easy GPT is a tiny wrapper around the OpenAI Responses API that aims to make
+chatting with OpenAI models simple and flexible. The package ships with
+comprehensive docstrings and literal type hints to improve IDE assistance.
+
+## Features
+
+- Choose any OpenAI model by name.
+- Optional streaming in both synchronous and asynchronous contexts.
+- Support for `AsyncOpenAI` via async helper methods.
+- Multiple assistants with independent system prompts.
+- Update system prompts at runtime with `update_system_prompt`.
+- Register custom function tools through `add_tool` or expose Python callables
+  with `add_function`.
+- Context tracking and simple garbage collection using `clear_context`.
+- API key pulled from the environment when not supplied explicitly.
+- Literal types for model and role names (`ModelName`, `Role`) provide IDE
+  autocompletion and safer code, while shared OpenAI clients and `dataclass`
+  slots deliver faster startup.
+
+## Quick start
+
+```python
+from easy_gpt import Assistant, ModelName
+
+# IDEs will offer suggestions for ModelName values
+assistant = Assistant(system_prompt="You are helpful.", model="gpt-4o-mini")
+print(assistant.ask("Hello, world!"))
+
+for partial in assistant.ask_stream("Write a limerick about Python"):
+    print(partial)
+```
+
+## Async usage
+
+```python
+import asyncio
+from easy_gpt import Assistant
+
+async def main():
+    bot = Assistant(system_prompt="You are helpful.")
+    reply = await bot.ask_async("What is 2 + 2?")
+    print(reply)
+
+asyncio.run(main())
+```
+
+## License
+
+MIT
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "easy-gpt"
+version = "0.2.1"
+description = "Lightweight typed wrapper around the OpenAI Responses API"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "openai>=1.0.0",
+]
+keywords = ["openai", "assistant", "typing", "literal"]
+license = {text = "MIT"}
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+


### PR DESCRIPTION
## Summary
- support Python callables as function tools with `add_function`
- invoke registered tools automatically when the model requests a call
- document callable tool support and clean up exports

## Testing
- `python -m py_compile Easy-gpt/assistant.py Easy-gpt/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc90c464948326b35ee41f76a1cbf4